### PR TITLE
Added due_on to the payload on create_task

### DIFF
--- a/asana/asana.py
+++ b/asana/asana.py
@@ -209,7 +209,8 @@ class AsanaAPI(object):
             payload['completed'] = 'true'
         if due_on:
             try:
-                vd = time.strptime(due_on, '%Y-%m-%d')
+                time.strptime(due_on, '%Y-%m-%d')
+                payload['due_on'] = due_on
             except ValueError:
                 raise Exception('Bad task due date: %s' % due_on)
         if followers:
@@ -243,7 +244,7 @@ class AsanaAPI(object):
             payload['completed'] = completed
         if due_on:
             try:
-                vd = time.strptime(due_on, '%Y-%m-%d')
+                time.strptime(due_on, '%Y-%m-%d')
                 payload['due_on'] = due_on
             except ValueError:
                 raise Exception('Bad task due date: %s' % due_on)


### PR DESCRIPTION
Due_on wasn't being used in the create_task method.  It was only being validated and stored in an unused variable.  Since that variable wasn't actually needed, I removed it.  update_task had a similar unused variable that I removed as well.  Some ipython tests I ran show that exceptions still bubble up as expected and that the due_on is being honored by the api.
