### PR TITLE
Change list_projects to match asana API

### DIFF
--- a/asana/asana.py
+++ b/asana/asana.py
@@ -250,16 +250,17 @@ class AsanaAPI(object):
         :param task_id: id# of task"""
         return self._asana("tasks/%d/subtasks" % task_id)
 
-    def list_projects(self, workspace=None, include_archived=True):
-        """"List projects in a workspace
+    def list_projects(self, workspace=None, archived=None):
+        """"List all projects in a workspace
 
         :param workspace: workspace whos projects you want to list
-        :param include_archived: defaults True, set to False to exclude """
-        if include_archived:
-            include_archived = "true"
-        else:
-            include_archived = "false"
-        target = "projects?archived=%s" % (include_archived)
+        :param archived: default None, filter by archived status
+        """
+        target = "projects"
+
+        if archived is not None:
+            target += "?archived=%d" % (archived)
+
         if workspace:
             target = "workspaces/%d/" % (workspace) + target
 


### PR DESCRIPTION
The asana API returns both archived and non-archived projects if the
archived parameter is omitted. If the parameter is provided it will
exclusively return archived or non-archived projects.

This is conform the docs at http://developer.asana.com/documentation/#projects

> archived: false
> If provided, this parameter will filter on projects whose archived field takes on the specified value.

This implementation will return all projects instead of archived only by default. If this change in behavior is not acceptable it may be required to implement a second list_all_projects/list_projects2 api call.

Also note that there are some other minor problems with the use of boolean defaults in the current implementation. For example it is currently not possible to set a project from archived=True to archived=False because the parameter is only included in the call if it is truthy. The same applies to tasks and their completed status.
